### PR TITLE
[Implement] CI/CD workflow for detekt and ktlint. Add sonatype publis…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: ci
+on: [ push, pull_request ]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: detekt
+        run: |
+          ./gradlew detektAll
+      - name: ktlint
+        run: |
+          ./gradlew ktlintCheck
+  cd-snapshot:
+    runs-on: macos-latest
+    needs: ci
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: publish snapshot sonatype
+        run: |
+          bash scripts/deploy-sonatype.sh
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+  cd-release:
+    runs-on: macos-latest
+    needs: ci
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - uses: little-core-labs/get-git-tag@v3.0.2
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      - name: publish release sonatype
+        run: |
+          bash scripts/deploy-sonatype.sh
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("multiplatform-library-convention")
+    id("publish-convention")
 }
 
 group = "net.humans.kmm.arch"

--- a/build-logic/src/main/kotlin/publish-convention.gradle.kts
+++ b/build-logic/src/main/kotlin/publish-convention.gradle.kts
@@ -1,0 +1,66 @@
+plugins {
+    `maven-publish`
+    signing
+}
+
+val releaseMode = project.findProperty("releaseMode")
+val versionSuffix = when (releaseMode) {
+    "RELEASE" -> ""
+    else -> "-SNAPSHOT"
+}
+val deploySonatypeUrl = when (releaseMode) {
+    "RELEASE" -> "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+    else -> "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+project.version = project.version.toString() + versionSuffix
+
+val javadocJar by tasks.registering(Jar::class) {
+    archiveClassifier.set("javadoc")
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "sonatype"
+            setUrl("deploySonatypeUrl")
+            credentials {
+                username = System.getenv("SONATYPE_USERNAME")
+                password = System.getenv("SONATYPE_PASSWORD")
+            }
+        }
+    }
+    publications.withType<MavenPublication> {
+        artifact(javadocJar)
+        pom {
+            name.set(project.name)
+            url.set("https://github.com/humans-group/humans-arch")
+            description.set("Common architecture components")
+            licenses {
+                license {
+                    name.set("MIT")
+                    url.set("https://opensource.org/licenses/MIT")
+                }
+            }
+            developers {
+                developer {
+                    id.set("humans-group")
+                    name.set("Humans Group")
+                    email.set("info@humans.net")
+                }
+            }
+            scm {
+                url.set("https://github.com/humans-group/humans-arch")
+            }
+        }
+    }
+}
+
+signing {
+    val passPhase = System.getenv("GPG_PASSPHRASE")
+    project.ext.set("signing.keyId", "TODO: projectId")
+    project.ext.set("signing.password", passPhase)
+    project.ext
+        .set("signing.secretKeyRingFile", "${project.rootProject.rootDir}/scripts/secring.gpg")
+    passPhase?.let { sign(publishing.publications) }
+}

--- a/data/result/build.gradle.kts
+++ b/data/result/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("multiplatform-library-convention")
+    id("publish-convention")
 }
 dependencies {
     commonMainImplementation(projects.annotations)

--- a/di/build.gradle.kts
+++ b/di/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("multiplatform-library-convention")
+    id("publish-convention")
 }
 
 group = "net.humans.arch.kmm"

--- a/domain/result/build.gradle.kts
+++ b/domain/result/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("multiplatform-library-convention")
+    id("publish-convention")
 }
 dependencies {
     commonMainImplementation(projects.annotations)

--- a/remote/error-handler/build.gradle.kts
+++ b/remote/error-handler/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("multiplatform-library-convention")
+    id("publish-convention")
 }
 dependencies {
     commonMainImplementation(projects.annotations)

--- a/remote/result/build.gradle.kts
+++ b/remote/result/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("multiplatform-library-convention")
+    id("publish-convention")
 }
 dependencies {
     commonMainImplementation(projects.annotations)

--- a/scripts/deploy-sonatype.sh
+++ b/scripts/deploy-sonatype.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+cd $(dirname $0)/..
+
+if [ -z "$SONATYPE_USERNAME" ]; then
+  echo "error: please set SONATYPE_USERNAME environment variable"
+  exit 1
+fi
+
+if [ -z "$SONATYPE_PASSWORD" ]; then
+  echo "error: please set SONATYPE_PASSWORD environment variable"
+  exit 1
+fi
+
+if [ -z "$GPG_PASSPHRASE" ]; then
+  echo "error: please set GPG_PASSPHRASE environment variable"
+  exit 1
+fi
+
+ASSEMBLE_TARGETS=""
+PUBLISH_TARGETS=""
+for i in ":annotations :data:result :di :domain:result :remote:error-handler :remote:result"; do
+  ASSEMBLE_TARGETS="$ASSEMBLE_TARGETS $i:assemble"
+  PUBLISH_TARGETS="$PUBLISH_TARGETS $i:publishAllPublicationsToSonatypeRepository"
+done
+
+if [ -z "$GIT_TAG_NAME" ]; then
+  echo "not on a tag -> deploy snapshot version"
+  ./gradlew $PUBLISH_TARGETS -PreleaseMode=SNAPSHOT
+else
+  echo "on a tag -> deploy release version $GIT_TAG_NAME"
+  ./gradlew $ASSEMBLE_TARGETS -PreleaseMode=RELEASE
+  ./gradlew $PUBLISH_TARGETS -PreleaseMode=RELEASE
+fi


### PR DESCRIPTION
Test results can be viewed at https://github.com/rasskazovaleksey/humans-arch/actions
ci_test task have been removed from MR
push to main will trigger SNAPSHOT deploy, tag will trigger RELEASE deploy

Needs to be added based on sonatype account
- [ ] secrets.SONATYPE_USERNAME
- [ ] secrets.SONATYPE_PASSWORD
- [ ] secrets.GPG_PASSPHRASE
- [ ] signing.keyId value to publish-conventions.gradle.kts
- [ ] secring to scripts/secring.gpg